### PR TITLE
Inline.php - fix lowercase name

### DIFF
--- a/lib/Horde/Text/Diff/Renderer/Inline.php
+++ b/lib/Horde/Text/Diff/Renderer/Inline.php
@@ -158,7 +158,7 @@ class Horde_Text_Diff_Renderer_Inline extends Horde_Text_Diff_Renderer
         }
 
         /* Get the diff in inline format. */
-        $renderer = new Horde_Text_Diff_Renderer_inline
+        $renderer = new Horde_Text_Diff_Renderer_Inline
             (array_merge($this->getParams(),
                          array('split_level' => $this->_split_characters ? 'characters' : 'words')));
 


### PR DESCRIPTION
Fix error in code, which references `Horde_Text_Diff_Renderer_inline` instead of `Horde_Text_Diff_Renderer_Inline` (mark the lower 'i')
Avoids a "class not found" error