### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Text/Diff/Engine/Native.php
+++ b/lib/Horde/Text/Diff/Engine/Native.php
@@ -26,6 +26,7 @@
  * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
  * @package Text_Diff
  */
+#[AllowDynamicProperties]
 class Horde_Text_Diff_Engine_Native
 {
     public function diff($from_lines, $to_lines)

--- a/lib/Horde/Text/Diff/ThreeWay/BlockBuilder.php
+++ b/lib/Horde/Text/Diff/ThreeWay/BlockBuilder.php
@@ -8,6 +8,7 @@
  * @package Text_Diff
  * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
  */
+#[\AllowDynamicProperties]
 class Horde_Text_Diff_ThreeWay_BlockBuilder
 {
     public function __construct()

--- a/lib/Horde/Text/Diff/ThreeWay/Op/Base.php
+++ b/lib/Horde/Text/Diff/ThreeWay/Op/Base.php
@@ -8,6 +8,7 @@
  * @package Text_Diff
  * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
  */
+#[\AllowDynamicProperties]
 class Horde_Text_Diff_ThreeWay_Op_Base
 {
     public function __construct($orig = false, $final1 = false, $final2 = false)

--- a/lib/Horde/Text/Diff/ThreeWay/Op/Copy.php
+++ b/lib/Horde/Text/Diff/ThreeWay/Op/Copy.php
@@ -8,6 +8,7 @@
  * @package Text_Diff
  * @author  Geoffrey T. Dairiki <dairiki@dairiki.org>
  */
+#[\AllowDynamicProperties]
 class Horde_Text_Diff_ThreeWay_Op_Copy extends Horde_Text_Diff_ThreeWay_Op_Base
 {
     public function __construct($lines = false)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Text/Diff/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Text/Diff/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Text_Diff Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Text/Diff/EngineTest.php
+++ b/test/Horde/Text/Diff/EngineTest.php
@@ -6,11 +6,11 @@
  * @package    Text_Diff
  * @subpackage UnitTests
  */
-class Horde_Text_Diff_EngineTest extends PHPUnit_Framework_TestCase
+class Horde_Text_Diff_EngineTest extends Horde_Test_Case
 {
     protected $_lines = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_lines = array(
             1 => file(__DIR__ . '/fixtures/1.txt'),
@@ -73,6 +73,8 @@ class Horde_Text_Diff_EngineTest extends PHPUnit_Framework_TestCase
 
     public function testXdiffEngine()
     {
+        $this->expectNotToPerformAssertions();
+
         try {
             $diff = new Horde_Text_Diff('Xdiff', array($this->_lines[1], $this->_lines[2]));
             $this->_testDiff($diff);

--- a/test/Horde/Text/Diff/RendererTest.php
+++ b/test/Horde/Text/Diff/RendererTest.php
@@ -10,7 +10,7 @@ class Horde_Text_Diff_RendererTest extends Horde_Test_Case
 {
     protected $_lines = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         for ($i = 1; $i <= 8; $i++) {
             $this->_lines[$i] = file(__DIR__ . '/fixtures/' . $i . '.txt');
@@ -266,6 +266,8 @@ END_OF_PATCH;
 
     public function testPearBug12710()
     {
+        $this->expectNotToPerformAssertions();
+
         /* failed assertion */
         $a = <<<QQ
 <li>The tax credit amounts to 30% of the cost of the system, with a

--- a/test/Horde/Text/Diff/ThreeWayTest.php
+++ b/test/Horde/Text/Diff/ThreeWayTest.php
@@ -10,7 +10,7 @@ class Horde_Text_Diff_ThreeWayTest extends Horde_Test_Case
 {
     protected $_lines = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         for ($i = 1; $i <= 4; $i++) {
             $this->_lines[$i] = file(__DIR__ . '/fixtures/' . $i . '.txt');

--- a/test/Horde/Text/Diff/phpunit.xml
+++ b/test/Horde/Text/Diff/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-text-diff/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-text-diff/-/blob/debian-sid/debian/patches/1012_php8.2.patch
