### PR TITLE
fix(src): disable assertion that crashes on certain input

### DIFF
--- a/src/NativeEngine.php
+++ b/src/NativeEngine.php
@@ -266,7 +266,12 @@ class NativeEngine implements DiffEngineInterface
                         $ymids[$k] = $ymids[$k - 1];
                         break;
                     } elseif ($y > $this->seq[$k - 1]) {
-                        assert($y <= $this->seq[$k]);
+                        /*
+                         * Disable this assertion for now until we know why it
+                         * causes https://github.com/maintaina-com/Text_Diff/issues/12
+                         * although when disabled the diff works as expected.
+                         */
+                        // assert($y <= $this->seq[$k]);
                         $this->in_seq[$this->seq[$k]] = false;
                         $this->seq[$k] = $y;
                         $this->in_seq[$y] = 1;


### PR DESCRIPTION
Port fix from lib/ (commit 39e6f62) to src/NativeEngine.php.
The assertion can fail even when the diff result is correct.

Related: https://github.com/maintaina-com/Text_Diff/issues/12
